### PR TITLE
Disable AI chat menu item with notice

### DIFF
--- a/src/app/(admin)/admin/chat/page.tsx
+++ b/src/app/(admin)/admin/chat/page.tsx
@@ -1,4 +1,3 @@
-import { LibraryChatInterface } from "@/components/chat/admin-chat-interface"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -8,8 +7,10 @@ export const metadata: Metadata = {
 
 export default function AdminChatPage() {
   return (
-    <div className=" w-full overflow-hidden rounded-xl border border-blue-100 bg-white shadow-sm">
-      <LibraryChatInterface />
+    <div className="flex h-[60vh] items-center justify-center rounded-xl border border-blue-100 bg-white p-6 shadow-sm">
+      <p className="text-center text-sm text-muted-foreground">
+        A seção de chat da IA está passando por ajustes no momento.
+      </p>
     </div>
   )
 }

--- a/src/app/(admin)/admin/loans/[id]/page.tsx
+++ b/src/app/(admin)/admin/loans/[id]/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link"
 import { getUserLibraryId } from "../actions"
 import { Suspense } from "react"
 import { Skeleton } from "@/components/ui/skeleton"
+import { UpdateLoanForm } from "@/components/loans/update-loan-form"
 
 // Definir tipos para os dados retornados pelo Supabase
 interface BookDetails {
@@ -343,6 +344,13 @@ async function LoanDetailsPageAsync({ params }: LoanDetailsPageProps) {
                   {loan.status === "overdue" && "Devolução atrasada"}
                   {loan.status === "rejected" && "Empréstimo rejeitado"}
                 </p>
+              </div>
+              <div className="mt-4">
+                <UpdateLoanForm
+                  loanId={loan.id}
+                  currentStatus={loan.status}
+                  currentDueDate={loan.due_date}
+                />
               </div>
             </CardContent>
             <Separator />

--- a/src/app/(admin)/admin/mobile-nav-item.tsx
+++ b/src/app/(admin)/admin/mobile-nav-item.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, HelpCircle } from 'lucide-react'
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import type React from "react"
@@ -14,9 +14,12 @@ interface MobileNavItemProps {
   description?: string
   badge?: number | null
   color?: string
+  disabled?: boolean
 }
 
-export function MobileNavItem({ href, icon: Icon, label, description, badge, color }: MobileNavItemProps) {
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+
+export function MobileNavItem({ href, icon: Icon, label, description, badge, color, disabled = false }: MobileNavItemProps) {
   const pathname = usePathname()
 
   const isActive = pathname === href || (href !== "/admin" && pathname.startsWith(href))
@@ -54,16 +57,16 @@ export function MobileNavItem({ href, icon: Icon, label, description, badge, col
 
   const colorKey = (color as keyof typeof colorClasses) || "blue"
 
-  return (
-    <Link
-      href={href}
-      className={cn(
-        "group flex items-center justify-between rounded-xl px-4 py-3 text-sm font-medium transition-all duration-300 ease-in-out relative overflow-hidden",
-        isActive
-          ? `${colorClasses[colorKey].active} transform scale-[1.02]`
-          : `text-slate-600 ${colorClasses[colorKey].inactive}`,
-      )}
-    >
+  const containerClasses = cn(
+    "group flex items-center justify-between rounded-xl px-4 py-3 text-sm font-medium transition-all duration-300 ease-in-out relative overflow-hidden",
+    isActive
+      ? `${colorClasses[colorKey].active} transform scale-[1.02]`
+      : `text-slate-600 ${colorClasses[colorKey].inactive}`,
+    disabled && "pointer-events-none opacity-60"
+  )
+
+  const content = (
+    <>
       {/* Efeito de brilho quando ativo */}
       {isActive && (
         <div className="absolute inset-0 bg-gradient-to-r from-white/20 to-transparent opacity-50 animate-pulse" />
@@ -106,12 +109,33 @@ export function MobileNavItem({ href, icon: Icon, label, description, badge, col
         </div>
       </div>
 
-      <ChevronRight
-        className={cn(
-          "h-4 w-4 transition-colors duration-300 relative z-10",
-          isActive ? "text-white" : "text-slate-400 group-hover:text-current",
-        )}
-      />
+      {disabled ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <HelpCircle className="h-4 w-4 text-slate-400" />
+            </TooltipTrigger>
+            <TooltipContent side="right">Em manutenção</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <ChevronRight
+          className={cn(
+            "h-4 w-4 transition-colors duration-300 relative z-10",
+            isActive ? "text-white" : "text-slate-400 group-hover:text-current",
+          )}
+        />
+      )}
+    </>
+  )
+
+  if (disabled) {
+    return <div className={containerClasses}>{content}</div>
+  }
+
+  return (
+    <Link href={href} className={containerClasses}>
+      {content}
     </Link>
   )
 }

--- a/src/app/(admin)/admin/nav-item.tsx
+++ b/src/app/(admin)/admin/nav-item.tsx
@@ -6,6 +6,9 @@ import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import type React from "react"
 
+import { HelpCircle } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+
 interface NavItemProps {
   href: string
   icon: React.ComponentType<{ className?: string }>
@@ -13,24 +16,25 @@ interface NavItemProps {
   description?: string
   badge?: number | null
   color?: string
+  disabled?: boolean
 }
 
-export function NavItem({ href, icon: Icon, label, description, badge }: NavItemProps) {
+export function NavItem({ href, icon: Icon, label, description, badge, disabled = false }: NavItemProps) {
   const pathname = usePathname()
 
   // Lógica mais precisa para determinar se o item está ativo
   const isActive = pathname === href || (href !== "/admin" && pathname.startsWith(href))
 
-  return (
-    <Link
-      href={href}
-      className={cn(
-        "group flex items-center gap-x-4 rounded-xl px-4 py-3.5 text-sm font-medium transition-all duration-200 ease-in-out border relative overflow-hidden",
-        isActive
-          ? "bg-blue-50 text-blue-700 border-blue-200 shadow-sm"
-          : "text-slate-600 hover:bg-blue-50/50 hover:text-blue-600 border-transparent hover:border-blue-100",
-      )}
-    >
+  const containerClasses = cn(
+    "group flex items-center gap-x-4 rounded-xl px-4 py-3.5 text-sm font-medium transition-all duration-200 ease-in-out border relative overflow-hidden",
+    isActive
+      ? "bg-blue-50 text-blue-700 border-blue-200 shadow-sm"
+      : "text-slate-600 hover:bg-blue-50/50 hover:text-blue-600 border-transparent hover:border-blue-100",
+    disabled && "pointer-events-none opacity-60"
+  )
+
+  const content = (
+    <>
       <div
         className={cn(
           "flex h-8 w-8 items-center justify-center rounded-lg transition-all duration-200",
@@ -75,6 +79,26 @@ export function NavItem({ href, icon: Icon, label, description, badge }: NavItem
       {isActive && (
         <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-1 h-8 bg-blue-500 rounded-l-full" />
       )}
+      {disabled && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <HelpCircle className="ml-auto h-4 w-4 text-muted-foreground" />
+            </TooltipTrigger>
+            <TooltipContent side="right">Em manutenção</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+    </>
+  )
+
+  if (disabled) {
+    return <div className={containerClasses}>{content}</div>
+  }
+
+  return (
+    <Link href={href} className={containerClasses}>
+      {content}
     </Link>
   )
 }

--- a/src/app/(admin)/admin/navigation.tsx
+++ b/src/app/(admin)/admin/navigation.tsx
@@ -41,6 +41,7 @@ export function Navigation({ recentLoansCount, isMobile = false }: NavigationPro
       icon: MessageCircle,
       label: "Chat IA",
       description: "Use IA para automatizar suas tarefas",
+      disabled: true,
     },
     {
       href: "/admin/settings",

--- a/src/components/library/LibraryClient.tsx
+++ b/src/components/library/LibraryClient.tsx
@@ -214,7 +214,9 @@ export default function LibraryClient({
           <BookMarked className="h-12 w-12 text-indigo-500" />
         </div>
       </div>
-      <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Bem-vindo à Biblioteca {library.name}</h1>
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4 break-words">
+        Bem-vindo à Biblioteca {library.name}
+      </h1>
       <p className="text-gray-500 dark:text-gray-400 max-w-2xl mx-auto mb-8 text-lg">
         {user
           ? "Explore nossa coleção de livros, faça empréstimos e gerencie sua conta de forma simples e intuitiva."
@@ -295,8 +297,10 @@ export default function LibraryClient({
               <div className="w-10 h-10 bg-gradient-to-br from-violet-500 to-indigo-600 rounded-xl flex items-center justify-center shadow-md">
                 <Library className="h-5 w-5 text-white" />
               </div>
-              <div>
-                <h2 className="text-lg font-bold text-gray-900 dark:text-white">{library.name}</h2>
+              <div className="min-w-0">
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white truncate">
+                  {library.name}
+                </h2>
                 <p className="text-sm text-gray-500 dark:text-gray-400">Sistema de Biblioteca</p>
               </div>
             </Link>
@@ -457,13 +461,16 @@ export default function LibraryClient({
                       <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
                         {count} resultado{count !== 1 ? "s" : ""} para {searchQuery}
                       </h2>
-                      <Button
-                        variant="ghost"
-                        onClick={() => router.push(`/biblioteca/${params.slug}`)}
-                        className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                      >
-                        Limpar busca
-                      </Button>
+                        <Button
+                          variant="ghost"
+                          onClick={() => {
+                            setSearchTerm("")
+                            router.push(`/biblioteca/${params.slug}`)
+                          }}
+                          className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                        >
+                          Limpar busca
+                        </Button>
                     </div>
 
                     <motion.div


### PR DESCRIPTION
## Summary
- disable the admin chat menu item
- show a help tooltip saying the AI section is under maintenance
- allow updating loan status from details page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686209609b68832b8fef57bb02c25a80